### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [created]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  update-latest:
+    # Only run this job when pushing to main, not during manual releases
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Delete old 'latest' release and tag
+        run: |
+          gh release delete latest --yes || true
+          git push origin :refs/tags/latest || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create new 'latest' tag
+        run: |
+          git tag -f latest
+          git push -f origin latest
+
+      - name: Create 'latest' release
+        run: |
+          gh release create latest --title "Latest Development Build" --notes "This is an automatically updated release containing the latest changes from the main branch." --prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-binaries:
+    needs: [update-latest]
+    if: github.event_name == 'push' || github.event_name == 'release'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: windows-latest
+            platform: windows
+          - os: macos-latest
+            platform: darwin
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Build binary
+        run: deno compile --allow-read --allow-write --allow-net --target ${{ matrix.platform }}-latest cli.ts -o trove-${{ matrix.platform }}
+
+      - name: Upload binary to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: trove-${{ matrix.platform }}*
+          tag_name: ${{ github.event_name == 'push' && 'latest' || github.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-docker:
+    needs: [update-latest]
+    if: github.event_name == 'push' || github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM denoland/deno:debian
+
+# Create app directory
+WORKDIR /app
+
+# Cache the dependencies as a layer
+COPY deno.lock* .
+# Copy the app source
+COPY . .
+RUN deno cache core/cli.ts
+
+# Compile the main app
+RUN deno compile --allow-read --allow-write --allow-net --output trove core/cli.ts
+
+# The binary runs with the correct permissions
+USER deno
+
+ENTRYPOINT ["/app/trove"]


### PR DESCRIPTION
This pull request defines a release workflow and Docker setup to streamline the build and release process, including the addition of a new GitHub Actions workflow for handling releases and updates to the `Dockerfile` to support building and running the application in a Docker container.

The objective of this release configuration is to maintain a 'latest' release, as well as tagged releases at milestones. 

It's worth noting that the binary as built at the moment is unlikely to remain, as [Deno does not handle dynamic imports when compiled](https://github.com/denoland/deno/issues/18327). I'm looking into fallbacks for this, which are likely to include a bootstrapping script which will install Deno and then run Trove locally.  This will apply to non-Docker installs only, since the Docker installs will simply run Trove within the container.