### PR TITLE
Build binaries on supported platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            platform: linux
+            platform: x86_64-unknown-linux-gnu
           - os: windows-latest
-            platform: windows
+            platform: x86_64-pc-windows-msvc
           - os: macos-latest
-            platform: darwin
+            platform: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This pull request updates the release configuration to build binaries on supported platforms:

- Linux amd64
- Windows amd64
- Mac OS arm64

