### PR TITLE
Remove stray suffix from platform to build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           deno-version: v2.x
 
       - name: Build binary
-        run: deno compile --allow-read --allow-write --allow-net --target ${{ matrix.platform }}-latest cli.ts -o trove-${{ matrix.platform }}
+        run: deno compile --allow-read --allow-write --allow-net --target ${{ matrix.platform }} cli.ts -o trove-${{ matrix.platform }}
 
       - name: Upload binary to release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
The previous pull request amended the platforms to build from, but I didn't notice a suffix on the build platform configuration. This pull request removes that suffix so the platform to build is undecorated.