### PR TITLE
Build core/cli.ts, not cli.ts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           deno-version: v2.x
 
       - name: Build binary
-        run: deno compile --allow-read --allow-write --allow-net --target ${{ matrix.platform }}-latest cli.ts -o trove-${{ matrix.platform }}
+        run: deno compile --allow-read --allow-write --allow-net --target ${{ matrix.platform }} core/cli.ts -o trove-${{ matrix.platform }}
 
       - name: Upload binary to release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This pull request addresses another build failure relating to trying to compile a file at the wrong location. Instead, we build core/cli.ts, which is what we should be doing.