### PR TITLE
Place output arg before the file arg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           deno-version: v2.x
 
       - name: Build binary
-        run: deno compile --allow-read --allow-write --allow-net --target ${{ matrix.platform }} core/cli.ts -o trove-${{ matrix.platform }}
+        run: deno compile --allow-read --allow-write --allow-net --target ${{ matrix.platform }} -o trove-${{ matrix.platform }} core/cli.ts
 
       - name: Upload binary to release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This pull request resolves a compile step error where the output arg is placed after, not before the file arg, resulting in a build failure.