### PR TITLE
Allocate write permissions to update an existing release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
 
   build-binaries:
     needs: [update-latest]
+    permissions:
+      contents: write
     if: github.event_name == 'push' || github.event_name == 'release'
     strategy:
       matrix:


### PR DESCRIPTION
While the binaries are now building, the release update step now requires additional permissions to attach binary files to the 'latest' release.