### PR TITLE
Add Bootstrap script, support config loading from multiple sources

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -e
+
+# Default values
+HEAD=false
+DENO_VERSION="2.2.8"
+CLI_URL="https://raw.githubusercontent.com/joshmcarthur/trove-project/refs/heads/main/core/cli.ts"
+REPO_GIT="https://github.com/joshmcarthur/trove-project.git"
+REPO_BRANCH="main"
+INSTALL_DIR="$HOME/.trove"
+DENO_DIR="$INSTALL_DIR/.deno"
+
+# Parse bootstrap arguments while preserving remaining args for CLI
+CLI_ARGS=()
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --head)
+            HEAD=true
+            shift
+            ;;
+        *)
+            CLI_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Restore CLI arguments
+set -- "${CLI_ARGS[@]}"
+
+# Detect OS
+case "$(uname -s)" in
+    Darwin*) OS="darwin" ;;
+    Linux*) OS="linux" ;;
+    MINGW*|MSYS*|CYGWIN*) OS="windows" ;;
+    *) echo "Unsupported operating system"; exit 1 ;;
+esac
+
+# Function to check if specific deno version exists in our install
+deno_version_exists() {
+    [ -f "$DENO_DIR/bin/deno" ] && "$DENO_DIR/bin/deno" --version | grep -q "$DENO_VERSION"
+}
+
+# Create installation directories
+mkdir -p "$DENO_DIR"
+
+# Install specific Deno version if not present
+if ! deno_version_exists; then
+    echo "Installing Deno $DENO_VERSION to $DENO_DIR..."
+
+    # Download Deno binary
+    curl -fsSL https://deno.land/x/install/install.sh | CI=true DENO_INSTALL="$DENO_DIR" sh -s "v$DENO_VERSION"
+
+    # Verify installation
+    if ! deno_version_exists; then
+        echo "Failed to install Deno v$DENO_VERSION. Please check your internet connection and try again."
+        exit 1
+    fi
+fi
+
+# Set up environment for Deno
+export DENO_INSTALL="$DENO_DIR"
+export PATH="$DENO_DIR/bin:$PATH"
+
+echo "Deno $DENO_VERSION is ready!"
+
+if [ "$HEAD" = true ]; then
+    echo "Installing development version from Git..."
+
+    # Create installation directory if it doesn't exist
+    mkdir -p "$INSTALL_DIR"
+
+    # Clone or update repository
+    if [ -d "$INSTALL_DIR/.git" ]; then
+        echo "Updating existing repository..."
+        cd "$INSTALL_DIR"
+        git pull origin "$REPO_BRANCH"
+    else
+        echo "Cloning repository..."
+        git clone "$REPO_GIT" "$INSTALL_DIR"
+        cd "$INSTALL_DIR"
+    fi
+
+    echo "Starting Trove from local installation..."
+    "$DENO_DIR/bin/deno" run --allow-net --allow-read --allow-write --allow-env --allow-run cli.ts "$@"
+else
+    echo "Starting Trove from stable release..."
+    "$DENO_DIR/bin/deno" run --allow-net --allow-read --allow-write --allow-env --allow-run "$CLI_URL" "$@"
+fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,6 +11,9 @@ TROVE_INSTALL_DIR="$HOME/.trove"
 TROVE_CLONE_DIR="$TROVE_INSTALL_DIR/git"
 DENO_DIR="$TROVE_INSTALL_DIR/.deno"
 
+# Store original working directory
+ORIGINAL_PWD="$PWD"
+
 # Parse bootstrap arguments while preserving remaining args for CLI
 CLI_ARGS=()
 while [[ "$#" -gt 0 ]]; do
@@ -85,6 +88,8 @@ if [ "$HEAD" = true ]; then
     fi
 
     echo "Starting Trove from local installation..."
+    # Run the CLI with the original working directory
+    cd "$ORIGINAL_PWD"
     "$DENO_DIR/bin/deno" run --allow-net --allow-read --allow-write --allow-env --allow-run "$TROVE_CLONE_DIR/core/cli.ts" "$@"
 else
     echo "Starting Trove from stable release..."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,11 +4,12 @@ set -e
 # Default values
 HEAD=false
 DENO_VERSION="2.2.8"
-CLI_URL="https://raw.githubusercontent.com/joshmcarthur/trove-project/refs/heads/main/core/cli.ts"
-REPO_GIT="https://github.com/joshmcarthur/trove-project.git"
-REPO_BRANCH="main"
-INSTALL_DIR="$HOME/.trove"
-DENO_DIR="$INSTALL_DIR/.deno"
+TROVE_CLI_URL="https://raw.githubusercontent.com/joshmcarthur/trove-project/refs/heads/main/core/cli.ts"
+TROVE_GIT="https://github.com/joshmcarthur/trove-project.git"
+TROVE_BRANCH="${TROVE_BRANCH:-main}"
+TROVE_INSTALL_DIR="$HOME/.trove"
+TROVE_CLONE_DIR="$TROVE_INSTALL_DIR/git"
+DENO_DIR="$TROVE_INSTALL_DIR/.deno"
 
 # Parse bootstrap arguments while preserving remaining args for CLI
 CLI_ARGS=()
@@ -68,21 +69,23 @@ if [ "$HEAD" = true ]; then
     echo "Installing development version from Git..."
 
     # Create installation directory if it doesn't exist
-    mkdir -p "$INSTALL_DIR"
+    mkdir -p "$TROVE_INSTALL_DIR"
 
     # Clone or update repository
-    if [ -d "$INSTALL_DIR/.git" ]; then
+    if [ -d "$TROVE_CLONE_DIR/.git" ]; then
         echo "Updating existing repository..."
-        cd "$INSTALL_DIR"
-        git pull origin "$REPO_BRANCH"
+        cd "$TROVE_CLONE_DIR"
+        git checkout "$TROVE_BRANCH"
+        git pull origin "$TROVE_BRANCH"
     else
         echo "Cloning repository..."
-        git clone "$REPO_GIT" "$INSTALL_DIR"
-        cd "$INSTALL_DIR"
+        mkdir -p "$TROVE_CLONE_DIR"
+        git clone "$TROVE_GIT" "$TROVE_CLONE_DIR" --branch "$TROVE_BRANCH"
+        cd "$TROVE_CLONE_DIR"
     fi
 
     echo "Starting Trove from local installation..."
-    "$DENO_DIR/bin/deno" run --allow-net --allow-read --allow-write --allow-env --allow-run cli.ts "$@"
+    "$DENO_DIR/bin/deno" run --allow-net --allow-read --allow-write --allow-env --allow-run "$TROVE_CLONE_DIR/core/cli.ts" "$@"
 else
     echo "Starting Trove from stable release..."
     "$DENO_DIR/bin/deno" run --allow-net --allow-read --allow-write --allow-env --allow-run "$CLI_URL" "$@"

--- a/core/config_loader.ts
+++ b/core/config_loader.ts
@@ -51,7 +51,9 @@ export class ConfigLoader {
           await Deno.stat(resolvedConfigPath);
         } catch (statError) {
           if (statError instanceof Deno.errors.NotFound) {
-            throw new Error(`Configuration file not found at: ${resolvedConfigPath}`);
+            throw new Error(
+              `Configuration file not found at: ${resolvedConfigPath}`,
+            );
           }
           throw statError;
         }
@@ -116,5 +118,4 @@ export class ConfigLoader {
     // PWD is more reliable than Deno.cwd() as it represents the shell's working directory
     return Deno.env.get("PWD") || Deno.cwd();
   }
-
 }

--- a/core/plugin_loader.ts
+++ b/core/plugin_loader.ts
@@ -41,11 +41,9 @@ export class PluginLoader {
         this.logger.info(`Loading plugin from URL/Specifier: ${source}`);
         await this._loadAndValidate(source, source);
       } else {
-        // Assume it's a local path (file or directory)
-        // Path normalization should happen before calling this (e.g., in loadConfig).
-        // If relative, resolve against CWD as a fallback.
+        // For local paths, always resolve relative to CWD
         const absoluteSourcePath = isAbsolute(source)
-          ? source
+          ? normalize(source)
           : normalize(join(Deno.cwd(), source));
 
         try {
@@ -54,7 +52,7 @@ export class PluginLoader {
             await this._loadFromDirectory(absoluteSourcePath);
           } else if (fileInfo.isFile) {
             this.logger.info(`Loading plugin from file: ${absoluteSourcePath}`);
-            const importUrl = new URL("file://" + absoluteSourcePath).href;
+            const importUrl = new URL(`file://${absoluteSourcePath}`).href;
             await this._loadAndValidate(absoluteSourcePath, importUrl);
           } else {
             this.logger.warn(
@@ -91,8 +89,7 @@ export class PluginLoader {
           continue;
         }
         const absolutePath = join(directory, entry.name);
-        const importUrl = new URL("file://" + absolutePath).href;
-        // Pass description and importUrl to the validation method
+        const importUrl = new URL(`file://${absolutePath}`).href;
         await this._loadAndValidate(absolutePath, importUrl);
       }
     } catch (error: unknown) {


### PR DESCRIPTION
This pull request introduces a bootstrap script which can be used to get Trove running quickly. The bootstrap script ensures that Deno is installed, and downloads it to a specific directory if not. It then runs Trove using a remote import with Deno, or alternatively supports running either HEAD (main), or a specific branch via a git clone. 

This makes it very easy to run Trove for people who don't want to use the Docker image. It also provides a recipe for those that might not want to install and/or run via a shell script.

Along with the bootstrap script, this PR also improves config and plugin loading to work with relative, absolute, and HTTPS imports. Previously, we had some problems with config importing outside the Trove repository folder, due to how Deno treats `Deno.pwd` as being derived based on the script path, rather than the shell PWD. This change means that now config and plugins can be loaded using any version of relative or absolute paths safely.